### PR TITLE
Spend from community pool

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -133,7 +133,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 	app.govKeeper = gov.NewKeeper(
 		app.cdc,
 		app.keyGov,
-		app.paramsKeeper, app.paramsKeeper.Subspace(gov.DefaultParamspace), app.bankKeeper, &stakeKeeper,
+		app.paramsKeeper, app.paramsKeeper.Subspace(gov.DefaultParamspace), app.bankKeeper, app.distrKeeper, &stakeKeeper,
 		gov.DefaultCodespace,
 	)
 

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -154,7 +154,8 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 
 	app.QueryRouter().
 		AddRoute("gov", gov.NewQuerier(app.govKeeper)).
-		AddRoute("stake", stake.NewQuerier(app.stakeKeeper, app.cdc))
+		AddRoute("stake", stake.NewQuerier(app.stakeKeeper, app.cdc)).
+		AddRoute("distr", distr.NewQuerier(app.distrKeeper, app.cdc))
 
 	// initialize BaseApp
 	app.MountStores(app.keyMain, app.keyAccount, app.keyStake, app.keyMint, app.keyDistr,

--- a/x/distribution/client/cli/query.go
+++ b/x/distribution/client/cli/query.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+)
+
+// GetCmdQueryFeePool implements the query fee pool command.
+func GetCmdQueryFeePool(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pool",
+		Args:  cobra.NoArgs,
+		Short: "Query the global fee pool",
+		Long:  "pool",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			// Query the proposal
+			res, err := queryFeePool(cliCtx, cdc, queryRoute)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(res))
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func queryFeePool(cliCtx context.CLIContext, cdc *codec.Codec, queryRoute string) ([]byte, error) {
+	// Query store
+	res, err := cliCtx.Query(fmt.Sprintf("custom/%s/feepool", queryRoute), []byte{})
+	if err != nil {
+		return nil, err
+	}
+	return res, err
+}

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -34,6 +34,7 @@ func GetTxCmd(storeKey string, cdc *amino.Codec) *cobra.Command {
 	distTxCmd.AddCommand(client.PostCommands(
 		GetCmdWithdrawRewards(cdc),
 		GetCmdSetWithdrawAddr(cdc),
+		GetCmdWithdrawBudget(cdc),
 	)...)
 
 	return distTxCmd
@@ -131,5 +132,38 @@ func GetCmdSetWithdrawAddr(cdc *codec.Codec) *cobra.Command {
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
 		},
 	}
+	return cmd
+}
+
+func GetCmdWithdrawBudget(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "withdraw-budget",
+		Short: "withdraw allocated budget",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().
+				WithCodec(cdc).
+				WithAccountDecoder(cdc)
+
+			var msg sdk.Msg
+
+			addr, err := cliCtx.GetFromAddress()
+			if err != nil {
+				return err
+			}
+
+			msg = types.NewMsgWithdrawBudgetAllocation(addr)
+
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
+			}
+
+			// build and sign the transaction, then broadcast to Tendermint
+			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
+		},
+	}
+
 	return cmd
 }

--- a/x/distribution/client/module_client.go
+++ b/x/distribution/client/module_client.go
@@ -19,7 +19,17 @@ func NewModuleClient(storeKey string, cdc *amino.Codec) ModuleClient {
 
 // GetQueryCmd returns the cli query commands for this module
 func (mc ModuleClient) GetQueryCmd() *cobra.Command {
-	return &cobra.Command{Hidden: true}
+	// Group gov queries under a subcommand
+	distrQueryCmd := &cobra.Command{
+		Use:   "dist",
+		Short: "Querying commands for the distribution module",
+	}
+
+	distrQueryCmd.AddCommand(client.GetCommands(
+		distCmds.GetCmdQueryFeePool(mc.storeKey, mc.cdc),
+	)...)
+
+	return distrQueryCmd
 }
 
 // GetTxCmd returns the transaction commands for this module
@@ -32,6 +42,7 @@ func (mc ModuleClient) GetTxCmd() *cobra.Command {
 	distTxCmd.AddCommand(client.PostCommands(
 		distCmds.GetCmdWithdrawRewards(mc.cdc),
 		distCmds.GetCmdSetWithdrawAddr(mc.cdc),
+		distCmds.GetCmdWithdrawBudget(mc.cdc),
 	)...)
 
 	return distTxCmd

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -19,6 +19,8 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return handleMsgWithdrawDelegatorReward(ctx, msg, k)
 		case types.MsgWithdrawValidatorRewardsAll:
 			return handleMsgWithdrawValidatorRewardsAll(ctx, msg, k)
+		case types.MsgWithdrawBudgetAllocation:
+			return handleMsgWithdrawBudgetAllocation(ctx, msg, k)
 		default:
 			return sdk.ErrTxDecode("invalid message parse in distribution module").Result()
 		}
@@ -80,6 +82,18 @@ func handleMsgWithdrawValidatorRewardsAll(ctx sdk.Context, msg types.MsgWithdraw
 	tags := sdk.NewTags(
 		tags.Validator, []byte(msg.ValidatorAddr.String()),
 	)
+	return sdk.Result{
+		Tags: tags,
+	}
+}
+
+func handleMsgWithdrawBudgetAllocation(ctx sdk.Context, msg types.MsgWithdrawBudgetAllocation, k keeper.Keeper) sdk.Result {
+	err := k.SpendFromCommunityPool(ctx, msg.BeneficiaryAddr)
+	if err != nil {
+		return err.Result()
+	}
+
+	tags := sdk.NewTags("budget-withdrawl", []byte(msg.BeneficiaryAddr))
 	return sdk.Result{
 		Tags: tags,
 	}

--- a/x/distribution/keeper/budget.go
+++ b/x/distribution/keeper/budget.go
@@ -1,0 +1,68 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+// AllocateCommunityFunds adds or creates to allocation for a beneficiary in a budget distinfo
+func (k Keeper) AllocateBudget(ctx sdk.Context, amount sdk.Coins, beneficiary sdk.AccAddress) {
+	distInfo := k.GetOrCreateBudgetDistInfo(ctx, beneficiary)
+	distInfo.AddAllocation(amount)
+	k.SetBudgetDistInfo(ctx, distInfo)
+}
+
+// SpendFromCommunityPool - Withdraws full budget from community pool, none if not enough funds
+func (k Keeper) SpendFromCommunityPool(ctx sdk.Context, beneficiary sdk.AccAddress) bool {
+	distInfo := k.GetOrCreateBudgetDistInfo(ctx, beneficiary)
+
+	// Does this beneficiary have any allocations?
+	if !distInfo.HasAllocation() {
+		return false
+	}
+
+	feePool := k.GetFeePool(ctx)
+
+	// Ensure we can withdraw full amount from community pool
+	success, communityPool, withdrawl := distInfo.WithdrawFromPool(feePool.CommunityPool)
+	if !success {
+		return false
+	}
+
+	// Make sure we did not over withdraw - this should be an invariant check?
+	if communityPool.HasNegative() {
+		return false
+	}
+
+	feePool.CommunityPool = communityPool
+	k.SetFeePool(ctx, feePool)
+	k.bankKeeper.AddCoins(ctx, beneficiary, withdrawl)
+	k.RemoveBudgetDistInfo(ctx, distInfo)
+	return true
+}
+
+// GetOrCreateBudgetDistInfo gets the budget distribution info for a beneficiary if exists or creates new
+func (k Keeper) GetOrCreateBudgetDistInfo(ctx sdk.Context, beneficiary sdk.AccAddress) (distInfo types.BudgetDistInfo) {
+	store := ctx.KVStore(k.storeKey)
+	b := store.Get(GetBudgetDistInfoKey(beneficiary))
+	if b == nil {
+		// construct a new dist info
+		return types.NewBudgetDistInfo(beneficiary)
+	}
+
+	k.cdc.MustUnmarshalBinaryLengthPrefixed(b, &distInfo)
+	return
+}
+
+// SetBudgetDistInfo sets the budget distribution info
+func (k Keeper) SetBudgetDistInfo(ctx sdk.Context, distInfo types.BudgetDistInfo) {
+	store := ctx.KVStore(k.storeKey)
+	b := k.cdc.MustMarshalBinaryLengthPrefixed(distInfo)
+	distInfoKey := GetBudgetDistInfoKey(distInfo.GetBeneficiary())
+	store.Set(distInfoKey, b)
+}
+
+func (k Keeper) RemoveBudgetDistInfo(ctx sdk.Context, distInfo types.BudgetDistInfo) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(GetBudgetDistInfoKey(distInfo.GetBeneficiary()))
+}

--- a/x/distribution/keeper/key.go
+++ b/x/distribution/keeper/key.go
@@ -11,6 +11,7 @@ var (
 	DelegationDistInfoKey    = []byte{0x02} // prefix for each key to a delegation distribution
 	DelegatorWithdrawInfoKey = []byte{0x03} // prefix for each key to a delegator withdraw info
 	ProposerKey              = []byte{0x04} // key for storing the proposer operator address
+	BudgetDistInfoKey        = []byte{0x05} // prefix for each key to a budget beneficiary withdraw info
 
 	// params store
 	ParamStoreKeyCommunityTax        = []byte("communitytax")
@@ -52,4 +53,9 @@ func GetDelegatorWithdrawInfoAddress(key []byte) (delAddr sdk.AccAddress) {
 		panic("unexpected key length")
 	}
 	return sdk.AccAddress(addr)
+}
+
+// gets the prefix for a budget withdraw info
+func GetBudgetDistInfoKey(delAddr sdk.AccAddress) []byte {
+	return append(BudgetDistInfoKey, delAddr.Bytes()...)
 }

--- a/x/distribution/querier.go
+++ b/x/distribution/querier.go
@@ -1,0 +1,33 @@
+package distribution
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// query endpoints supported by the governance Querier
+const (
+	QueryCommunityPool = "feepool"
+)
+
+func NewQuerier(keeper Keeper, cdc *codec.Codec) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, sdk.Error) {
+		switch path[0] {
+		case QueryCommunityPool:
+			return queryFeePool(ctx, path[1:], req, keeper, cdc)
+		default:
+			return nil, sdk.ErrUnknownRequest("unknown distribution query endpoint")
+		}
+	}
+}
+
+func queryFeePool(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper, cdc *codec.Codec) ([]byte, sdk.Error) {
+
+	bz, err := codec.MarshalJSONIndent(cdc, keeper.GetFeePool(ctx))
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+	return bz, nil
+
+}

--- a/x/distribution/types/budget_info.go
+++ b/x/distribution/types/budget_info.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BudgetDistInfo distribution information for a budget
+type BudgetDistInfo struct {
+	BeneficiaryAddr     sdk.AccAddress `json:"beneficiary_addr"`
+	WithdrawlAllocation sdk.Coins      `json:"allocation"` // funds allocated remaining to be withdrawn
+}
+
+func NewBudgetDistInfo(beneficiary sdk.AccAddress) BudgetDistInfo {
+	return BudgetDistInfo{beneficiary, sdk.Coins{}}
+}
+
+func (distInfo BudgetDistInfo) GetBeneficiary() sdk.AccAddress {
+	return distInfo.BeneficiaryAddr
+}
+
+// Add adds coins to the allocation for the budget beneficiary
+func (distInfo *BudgetDistInfo) AddAllocation(amount sdk.Coins) {
+	distInfo.WithdrawlAllocation = distInfo.WithdrawlAllocation.Plus(amount)
+}
+
+func (distInfo BudgetDistInfo) HasAllocation() bool {
+	return !distInfo.WithdrawlAllocation.IsZero()
+}
+
+func (distInfo *BudgetDistInfo) WithdrawFromPool(pool DecCoins) (bool, DecCoins, sdk.Coins) {
+	newPool := pool.Minus(NewDecCoins(distInfo.WithdrawlAllocation))
+
+	if newPool.HasNegative() {
+		return false, pool, sdk.Coins{}
+	}
+
+	withdrawl := distInfo.WithdrawlAllocation
+	distInfo.WithdrawlAllocation = sdk.Coins{}
+
+	return true, newPool, withdrawl
+}

--- a/x/distribution/types/codec.go
+++ b/x/distribution/types/codec.go
@@ -10,6 +10,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgWithdrawDelegatorReward{}, "cosmos-sdk/MsgWithdrawDelegationReward", nil)
 	cdc.RegisterConcrete(MsgWithdrawValidatorRewardsAll{}, "cosmos-sdk/MsgWithdrawValidatorRewardsAll", nil)
 	cdc.RegisterConcrete(MsgSetWithdrawAddress{}, "cosmos-sdk/MsgModifyWithdrawAddress", nil)
+	cdc.RegisterConcrete(MsgWithdrawBudgetAllocation{}, "cosmos-sdk/MsgWithdrawBudgetAllocation", nil)
 }
 
 // generic sealed codec to be used throughout module

--- a/x/distribution/types/errors.go
+++ b/x/distribution/types/errors.go
@@ -28,3 +28,9 @@ func ErrNoDelegationDistInfo(codespace sdk.CodespaceType) sdk.Error {
 func ErrNoValidatorDistInfo(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeNoDistributionInfo, "no validator distribution info")
 }
+func ErrWithdrawerHasNoAllocation(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeNoDistributionInfo, "withdrawer has no budget allocated")
+}
+func ErrPoolDoesNotHaveEnoughFunds(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeNoDistributionInfo, "pool does not have enough funds")
+}

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -11,6 +11,7 @@ const MsgRoute = "distr"
 // Verify interface at compile time
 var _, _ sdk.Msg = &MsgSetWithdrawAddress{}, &MsgWithdrawDelegatorRewardsAll{}
 var _, _ sdk.Msg = &MsgWithdrawDelegatorReward{}, &MsgWithdrawValidatorRewardsAll{}
+var _ sdk.Msg = &MsgWithdrawBudgetAllocation{}
 
 //______________________________________________________________________
 
@@ -169,6 +170,42 @@ func (msg MsgWithdrawValidatorRewardsAll) GetSignBytes() []byte {
 // quick validity check
 func (msg MsgWithdrawValidatorRewardsAll) ValidateBasic() sdk.Error {
 	if msg.ValidatorAddr == nil {
+		return ErrNilValidatorAddr(DefaultCodespace)
+	}
+	return nil
+}
+
+// msg struct for withdrawing budget
+type MsgWithdrawBudgetAllocation struct {
+	BeneficiaryAddr sdk.AccAddress `json:"beneficiary_addr"`
+}
+
+func NewMsgWithdrawBudgetAllocation(beneficiary sdk.AccAddress) MsgWithdrawBudgetAllocation {
+	return MsgWithdrawBudgetAllocation{
+		BeneficiaryAddr: beneficiary,
+	}
+}
+
+func (msg MsgWithdrawBudgetAllocation) Route() string { return MsgRoute }
+func (msg MsgWithdrawBudgetAllocation) Type() string  { return "withdraw_budget_allocation" }
+
+// Return address that must sign over msg.GetSignBytes()
+func (msg MsgWithdrawBudgetAllocation) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{sdk.AccAddress(msg.BeneficiaryAddr.Bytes())}
+}
+
+// get the bytes for the message signer to sign on
+func (msg MsgWithdrawBudgetAllocation) GetSignBytes() []byte {
+	b, err := MsgCdc.MarshalJSON(msg)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(b)
+}
+
+// quick validity check
+func (msg MsgWithdrawBudgetAllocation) ValidateBasic() sdk.Error {
+	if msg.BeneficiaryAddr == nil {
 		return ErrNilValidatorAddr(DefaultCodespace)
 	}
 	return nil

--- a/x/gov/client/utils/utils.go
+++ b/x/gov/client/utils/utils.go
@@ -24,6 +24,8 @@ func NormalizeProposalType(proposalType string) string {
 		return "ParameterChange"
 	case "SoftwareUpgrade", "software_upgrade":
 		return "SoftwareUpgrade"
+	case "Budger", "budget":
+		return "Budget"
 	}
 	return ""
 }

--- a/x/gov/errors.go
+++ b/x/gov/errors.go
@@ -65,3 +65,7 @@ func ErrInvalidVote(codespace sdk.CodespaceType, voteOption VoteOption) sdk.Erro
 func ErrInvalidGenesis(codespace sdk.CodespaceType, msg string) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidVote, msg)
 }
+
+func ErrInvalidTokensInBudget(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeUnknownProposal, fmt.Sprintf("Only bond tokens can be used in budget proposals"))
+}

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -28,7 +28,10 @@ func handleMsgSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSubmitPropos
 	proposal := keeper.NewTextProposal(ctx, msg.Title, msg.Description, msg.ProposalType)
 
 	if msg.ProposalType == ProposalTypeBudget {
-		keeper.SetBudgetAndBeneficiary(ctx, proposal.GetProposalID(), msg.Budget, msg.Beneficirary)
+		err := keeper.SetBudgetAndBeneficiary(ctx, proposal.GetProposalID(), msg.Budget, msg.Beneficirary)
+		if err != nil {
+			return err.Result()
+		}
 	}
 
 	err, votingStarted := keeper.AddDeposit(ctx, proposal.GetProposalID(), msg.Proposer, msg.InitialDeposit)

--- a/x/gov/keeper.go
+++ b/x/gov/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/params"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 	"github.com/tendermint/tendermint/crypto"
 )
 
@@ -459,11 +460,21 @@ func (keeper Keeper) SetBudgetAndBeneficiary(ctx sdk.Context, proposalID uint64,
 	if proposal == nil {
 		return ErrUnknownProposal(keeper.codespace, proposalID)
 	}
+
+	// Limit budget to the bond token, stakeTypes.DefaultBondDenom
+	if !hasOnlyBondTokens(budget) {
+		return ErrInvalidTokensInBudget(keeper.codespace)
+	}
+
 	proposal.SetBudget(budget)
 	proposal.SetBeneficiary(beneficiary)
 	keeper.SetProposal(ctx, proposal)
 
 	return nil
+}
+
+func hasOnlyBondTokens(coins sdk.Coins) bool {
+	return len(coins) == 1 && coins[0].Denom == stakeTypes.DefaultBondDenom
 }
 
 // =====================================================

--- a/x/gov/keeper.go
+++ b/x/gov/keeper.go
@@ -6,8 +6,8 @@ import (
 	codec "github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/params"
-
 	"github.com/tendermint/tendermint/crypto"
 )
 
@@ -46,6 +46,9 @@ type Keeper struct {
 	// The reference to the CoinKeeper to modify balances
 	ck bank.Keeper
 
+	// The reference to the Distribution Keeper to spend from community pool
+	distrk distribution.Keeper
+
 	// The ValidatorSet to get information about validators
 	vs sdk.ValidatorSet
 
@@ -67,12 +70,13 @@ type Keeper struct {
 // - depositing funds into proposals, and activating upon sufficient funds being deposited
 // - users voting on proposals, with weight proportional to stake in the system
 // - and tallying the result of the vote.
-func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramsKeeper params.Keeper, paramSpace params.Subspace, ck bank.Keeper, ds sdk.DelegationSet, codespace sdk.CodespaceType) Keeper {
+func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramsKeeper params.Keeper, paramSpace params.Subspace, ck bank.Keeper, distrk distribution.Keeper, ds sdk.DelegationSet, codespace sdk.CodespaceType) Keeper {
 	return Keeper{
 		storeKey:     key,
 		paramsKeeper: paramsKeeper,
 		paramSpace:   paramSpace.WithTypeTable(ParamTypeTable()),
 		ck:           ck,
+		distrk:       distrk,
 		ds:           ds,
 		vs:           ds.GetValidatorSet(),
 		cdc:          cdc,
@@ -447,6 +451,19 @@ func (keeper Keeper) DeleteDeposits(ctx sdk.Context, proposalID uint64) {
 	}
 
 	depositsIterator.Close()
+}
+
+func (keeper Keeper) SetBudgetAndBeneficiary(ctx sdk.Context, proposalID uint64, budget sdk.Coins, beneficiary sdk.AccAddress) sdk.Error {
+	// Checks to see if proposal exists
+	proposal := keeper.GetProposal(ctx, proposalID)
+	if proposal == nil {
+		return ErrUnknownProposal(keeper.codespace, proposalID)
+	}
+	proposal.SetBudget(budget)
+	proposal.SetBeneficiary(beneficiary)
+	keeper.SetProposal(ctx, proposal)
+
+	return nil
 }
 
 // =====================================================

--- a/x/gov/msgs.go
+++ b/x/gov/msgs.go
@@ -19,6 +19,8 @@ type MsgSubmitProposal struct {
 	ProposalType   ProposalKind   `json:"proposal_type"`   //  Type of proposal. Initial set {PlainTextProposal, SoftwareUpgradeProposal}
 	Proposer       sdk.AccAddress `json:"proposer"`        //  Address of the proposer
 	InitialDeposit sdk.Coins      `json:"initial_deposit"` //  Initial deposit paid by sender. Must be strictly positive.
+	Budget         sdk.Coins      `json:"budget"`          //  Proposed funds to sepnd from community pool funds
+	Beneficirary   sdk.AccAddress `json:"beneficiary"`     //  Recipient of proposed fund
 }
 
 func NewMsgSubmitProposal(title string, description string, proposalType ProposalKind, proposer sdk.AccAddress, initialDeposit sdk.Coins) MsgSubmitProposal {
@@ -28,6 +30,18 @@ func NewMsgSubmitProposal(title string, description string, proposalType Proposa
 		ProposalType:   proposalType,
 		Proposer:       proposer,
 		InitialDeposit: initialDeposit,
+	}
+}
+
+func NewMsgSubmitBudgetProposal(title string, description string, proposer sdk.AccAddress, initialDeposit sdk.Coins, budget sdk.Coins, beneficiary sdk.AccAddress) MsgSubmitProposal {
+	return MsgSubmitProposal{
+		Title:          title,
+		Description:    description,
+		ProposalType:   ProposalTypeBudget,
+		Proposer:       proposer,
+		InitialDeposit: initialDeposit,
+		Budget:         budget,
+		Beneficirary:   beneficiary,
 	}
 }
 
@@ -55,11 +69,20 @@ func (msg MsgSubmitProposal) ValidateBasic() sdk.Error {
 	if !msg.InitialDeposit.IsNotNegative() {
 		return sdk.ErrInvalidCoins(msg.InitialDeposit.String())
 	}
+	if msg.ProposalType == ProposalTypeBudget {
+		if !msg.Budget.IsValid() {
+			return sdk.ErrInvalidCoins(msg.Budget.String())
+		}
+		if !msg.Budget.IsNotNegative() {
+			return sdk.ErrInvalidCoins(msg.InitialDeposit.String())
+		}
+	}
+
 	return nil
 }
 
 func (msg MsgSubmitProposal) String() string {
-	return fmt.Sprintf("MsgSubmitProposal{%s, %s, %s, %v}", msg.Title, msg.Description, msg.ProposalType, msg.InitialDeposit)
+	return fmt.Sprintf("MsgSubmitProposal{%s, %s, %s, %v, %v, %v}", msg.Title, msg.Description, msg.ProposalType, msg.InitialDeposit, msg.Budget, msg.Beneficirary)
 }
 
 // Implements Msg.


### PR DESCRIPTION
Basic implementation of budget proposal, allows spending from the community pool.
New proposal type 'Budget' can have a recipient and a budget of coins. If the proposal passes a budget distribution is allocated to the recipient in the distribution module. The recipient must then send a 'withdraw-budget' transaction to withdraw from the community pool. There must be enough funds in the pool to do a full withdrawal or no transfer occurs. Recipient can try to withdraw again at a later time once funds are available in the pool.

This very simplistic model places burden on voters to ensure fair allocation of pool funds and to only pass proposals that can be covered by the pool. 

Usage:

Check how much is available in the community fee pool:

```bash
joycli query dist pool

{
  "val_accum": {
    "update_height": "0",
    "accum": "0.0000000000"
  },
  "val_pool": [
    {
      "denom": "joy",
      "amount": "356.4000000000"
    }
  ],
  "community_pool": [
    {
      "denom": "joy",
      "amount": "39.0000000000"
    }
  ]
}
```

Create a budget proposal
myproposal.json
```json
{
  "title": "Test Budget Proposal - A",
  "description": "run a meetup in my city ",
  "type": "Budget",
  "deposit": "10joy",
  "beneficiary": "joystream1psujwz0g40ms8tal7vcp5nuz2pndjc4tpw8pxz",
  "budget": "5joy"
}
```

Submit the proposal
```bash
joycli tx gov submit-proposal --proposal ./myproposal.json --from mokhtar
```

Withdraw funds (after vote passes)
```bash
joycli tx dist withdraw-budget --from mokhtar
```

